### PR TITLE
Fix/users can now go back freely between step 1 and 2 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,6 +83,7 @@ const HomeContent: React.FC = () => {
           currentStep={currentStep}
           setCurrentStep={(step) => setCurrentStep(step)}
           completedSteps={completedSteps}
+          isCsvUploaded={!!csvFile}
         />
 
         <div className="flex flex-col h-full w-full p-4">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 type Step = {
   name: string;
-  component: React.FC<{ onComplete: () => void }>;
+  component: React.FC<any>;
 };
 
 interface SidebarProps {
@@ -12,24 +12,41 @@ interface SidebarProps {
   currentStep: number;
   setCurrentStep: React.Dispatch<React.SetStateAction<number>>;
   completedSteps: boolean[];
+  isCsvUploaded: boolean; // Added here
 }
 
-// TODO: Adjust logic for step completion
-const Sidebar: React.FC<SidebarProps> = ({ steps, currentStep, setCurrentStep, completedSteps }) => {
+const Sidebar: React.FC<SidebarProps> = ({
+  steps,
+  currentStep,
+  setCurrentStep,
+  completedSteps,
+  isCsvUploaded,
+}) => {
   return (
     <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
       {steps.map((step, index) => (
         <button
           key={index}
           onClick={() => {
-            if (index === currentStep || completedSteps[index] || index === currentStep - 1) {
+            if (
+              index === currentStep ||
+              completedSteps[index] ||
+              (index === 1 && isCsvUploaded) || // Allow step 2 if CSV is uploaded
+              index === currentStep - 1
+            ) {
               setCurrentStep(index);
             }
           }}
           className={`w-8 h-8 ${
-            index <= currentStep ? "cursor-pointer" : "cursor-not-allowed"
-          } ${completedSteps[index] || index === currentStep ? "bg-blue-500" : "bg-gray-300"}`}
-          disabled={!completedSteps[index] && index > currentStep} // Disable next steps if they’re not completed
+            index <= currentStep || (index === 1 && isCsvUploaded)
+              ? "cursor-pointer"
+              : "cursor-not-allowed"
+          } ${
+            completedSteps[index] || index === currentStep
+              ? "bg-blue-500"
+              : "bg-gray-300"
+          }`}
+          disabled={!completedSteps[index] && index > currentStep && !(index === 1 && isCsvUploaded)} // Enable step 2 if CSV is uploaded
         >
           {index + 1}
         </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,33 +24,35 @@ const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   return (
     <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
-      {steps.map((step, index) => (
-        <button
-          key={index}
-          onClick={() => {
-            if (
-              index === currentStep ||
-              completedSteps[index] ||
-              (index === 1 && isCsvUploaded) || // Allow step 2 if CSV is uploaded
-              index === currentStep - 1
-            ) {
-              setCurrentStep(index);
-            }
-          }}
-          className={`w-8 h-8 ${
-            index <= currentStep || (index === 1 && isCsvUploaded)
-              ? "cursor-pointer"
-              : "cursor-not-allowed"
-          } ${
-            completedSteps[index] || index === currentStep
-              ? "bg-blue-500"
-              : "bg-gray-300"
-          }`}
-          disabled={!completedSteps[index] && index > currentStep && !(index === 1 && isCsvUploaded)} // Enable step 2 if CSV is uploaded
-        >
-          {index + 1}
-        </button>
-      ))}
+      {steps.map((step, index) => {
+        const isDisabled =
+          !completedSteps[index] &&
+          index > currentStep &&
+          !(index === 1 && isCsvUploaded); // Step 2 is disabled if CSV is not uploaded
+
+        return (
+          <button
+            key={index}
+            onClick={() => {
+              if (!isDisabled) {
+                setCurrentStep(index);
+              }
+            }}
+            className={`w-8 h-8 ${
+              index <= currentStep || (index === 1 && isCsvUploaded)
+                ? "cursor-pointer"
+                : "cursor-not-allowed"
+            } ${
+              completedSteps[index] || index === currentStep
+                ? "bg-blue-500"
+                : "bg-gray-300"
+            }`}
+            disabled={isDisabled}
+          >
+            {index + 1}
+          </button>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
fixes #22 

before: if uploaded na yung csv, then proceed to step 2, then click step 1 ulit, hindi ka na ulit makakabalik sa step 2 unless iclick mo next
after/fix: user can now go back and forth between step 1 and 2, provided na may uploaded csv file sha, if walang csv, disabled step 2

https://github.com/user-attachments/assets/54e9d11f-e733-482b-806e-a73dbdba02e9

files modified:
`Sidebar.tsx` - added `isCsvUploaded `property to `SidebarProps`
`page.tsx` - added `isCsvUploaded `argument to `Sidebar`
basically added a checker if uploaded na yung csv file

**issue**:
if user advances to step 3, logic is broken and nasisira na sila completely (kahit walang csv nakakapag jump sila ng steps)


