### PR TITLE
Fix/step 3 bug jumping steps

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ const steps: Step[] = [
 const HomeContent: React.FC = () => {
   const [currentStep, setCurrentStep] = useState<number>(0);
   const [completedSteps, setCompletedSteps] = useState<boolean[]>([false, false, false]);
+  const [cleanedData, setCleanedData] = useState<any[]>([]); 
 
   const { csvFile, csvData, clearFile, handleFileLoaded } = useContext(CsvContext);
 
@@ -44,10 +45,16 @@ const HomeContent: React.FC = () => {
   const completeCurrentStep = () => {
     setCompletedSteps((prevSteps) => {
       const newSteps = [...prevSteps];
-      newSteps[currentStep] = true;
+      if (!newSteps[currentStep]) {
+        newSteps[currentStep] = true; // Mark the current step as complete
+      }
       return newSteps;
     });
-    handleNext(); // Automatically move to the next step
+  
+    // Increment `currentStep` only if it is within bounds
+    if (currentStep < steps.length - 1) {
+      setCurrentStep(currentStep + 1);
+    }
   };
 
   // Reset steps when clearing the file
@@ -92,6 +99,8 @@ const HomeContent: React.FC = () => {
             clearFile={clearFile}
             resetSteps={resetSteps} // Pass resetSteps to components
             goToDataCleaningStep={() => setCurrentStep(1)}
+            setCleanedData={setCleanedData} // Pass setCleanedData here
+            cleanedData={cleanedData} // Pass cleanedData to the visualization step
           />
 
           <div className="flex space-x-4 mt-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,14 +26,9 @@ const HomeContent: React.FC = () => {
 
   const { csvFile, csvData, clearFile, handleFileLoaded } = useContext(CsvContext);
 
-  // Go to the data cleaning step (2nd step)
-  const goToDataCleaningStep = () => {
-    setCurrentStep(1);
-  };
-
   // Move to the next step
   const handleNext = () => {
-    if (currentStep < steps.length - 1) {
+    if (currentStep < steps.length - 1 && completedSteps[currentStep]) {
       setCurrentStep(currentStep + 1);
     }
   };
@@ -47,17 +42,18 @@ const HomeContent: React.FC = () => {
 
   // Mark the current step as complete
   const completeCurrentStep = () => {
-    console.log("Completing current step:", currentStep);
     setCompletedSteps((prevSteps) => {
-      if (prevSteps[currentStep]) {
-        return prevSteps; // No change if already complete
-      }
       const newSteps = [...prevSteps];
       newSteps[currentStep] = true;
-      console.log("Updated steps:", newSteps);
       return newSteps;
     });
     handleNext(); // Automatically move to the next step
+  };
+
+  // Reset steps when clearing the file
+  const resetSteps = () => {
+    setCompletedSteps([false, false, false]);
+    setCurrentStep(0);
   };
 
   // Render the current step's component
@@ -81,7 +77,7 @@ const HomeContent: React.FC = () => {
         <Sidebar
           steps={steps}
           currentStep={currentStep}
-          setCurrentStep={(step) => setCurrentStep(step)}
+          setCurrentStep={setCurrentStep}
           completedSteps={completedSteps}
           isCsvUploaded={!!csvFile}
         />
@@ -94,8 +90,8 @@ const HomeContent: React.FC = () => {
             csvData={csvData}
             handleFileLoaded={handleFileLoaded}
             clearFile={clearFile}
-            goToDataCleaningStep={goToDataCleaningStep}
-            cleanedData={csvData} // TODO: Pass cleaned data to visualization step (placeholder as of now)
+            resetSteps={resetSteps} // Pass resetSteps to components
+            goToDataCleaningStep={() => setCurrentStep(1)}
           />
 
           <div className="flex space-x-4 mt-8">
@@ -112,7 +108,6 @@ const HomeContent: React.FC = () => {
   );
 };
 
-// TODO: Set global css properties
 export default function Home() {
   return (
     <CsvContextProvider>

--- a/src/components/CleanPage.tsx
+++ b/src/components/CleanPage.tsx
@@ -7,10 +7,11 @@ import { CsvContext } from "../lib/CsvContext";
 
 interface CleanPageProps {
   onBack: () => void;
-  onComplete: () => void; // New prop for completing this step
+  onComplete: () => void;
+  setCleanedData: (data: any[]) => void;
 }
 
-const CleanPage: React.FC<CleanPageProps> = ({ onBack, onComplete }) => {
+const CleanPage: React.FC<CleanPageProps> = ({ onBack, onComplete, setCleanedData }) => {
   const { csvData } = useContext(CsvContext);
 
   if (csvData.length === 0) {
@@ -26,14 +27,13 @@ const CleanPage: React.FC<CleanPageProps> = ({ onBack, onComplete }) => {
 
   const rows = csvData.map((row, index) => ({ id: index, ...row }));
 
-  const [paginationModel, setPaginationModel] = React.useState<GridPaginationModel>({
-    pageSize: 10,
-    page: 0,
-  });
-
-  const handlePaginationChange = (model: GridPaginationModel) => {
-    setPaginationModel(model);
+  const handleCleanData = () => {
+    const cleanedData = csvData.map((row) => ({ ...row, cleaned: true })); // Example cleaning transformation
+    console.log("Cleaned Data:", cleanedData); // Debugging output
+    setCleanedData(cleanedData); // Pass cleaned data to the next step
+    onComplete(); // Mark step 2 as complete and automatically move to step 3
   };
+  
 
   return (
     <Box sx={{ p: 2 }}>
@@ -44,10 +44,7 @@ const CleanPage: React.FC<CleanPageProps> = ({ onBack, onComplete }) => {
         Back to Upload
       </Button>
       <Button
-        onClick={() => {
-          console.log("Clean Data button clicked");
-          onComplete();
-        }}
+        onClick={handleCleanData}
         variant="contained"
         color="secondary"
         sx={{ mb: 2, ml: 2 }}
@@ -58,9 +55,6 @@ const CleanPage: React.FC<CleanPageProps> = ({ onBack, onComplete }) => {
         <DataGrid
           rows={rows}
           columns={columns}
-          pagination
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationChange}
           pageSizeOptions={[5, 10, 20]}
           checkboxSelection
         />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,11 +38,11 @@ const Sidebar: React.FC<SidebarProps> = ({
               }
             }}
             className={`w-8 h-8 ${
-              index <= currentStep || (index === 1 && isCsvUploaded)
+              index <= currentStep || (index === 1 && isCsvUploaded) || (index === 0 && isCsvUploaded) // Ensure Step 1 stays interactive and blue if a CSV is uploaded
                 ? "cursor-pointer"
                 : "cursor-not-allowed"
             } ${
-              completedSteps[index] || index === currentStep
+              completedSteps[index] || index === currentStep || (index === 0 && isCsvUploaded) // Ensure Step 1 is blue if a CSV is uploaded
                 ? "bg-blue-500"
                 : "bg-gray-300"
             }`}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ interface SidebarProps {
   currentStep: number;
   setCurrentStep: React.Dispatch<React.SetStateAction<number>>;
   completedSteps: boolean[];
-  isCsvUploaded: boolean; // Added here
+  isCsvUploaded: boolean;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -25,10 +25,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   return (
     <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
       {steps.map((step, index) => {
-        const isDisabled =
-          !completedSteps[index] &&
-          index > currentStep &&
-          !(index === 1 && isCsvUploaded); // Step 2 is disabled if CSV is not uploaded
+         const isDisabled =
+         (index === 1 && !isCsvUploaded) || // Step 2 requires CSV to be uploaded
+         (index === 2 && !completedSteps[1]); // Step 3 requires Step 2 to be completed
 
         return (
           <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,9 +25,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   return (
     <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
       {steps.map((step, index) => {
-         const isDisabled =
-         (index === 1 && !isCsvUploaded) || // Step 2 requires CSV to be uploaded
-         (index === 2 && !completedSteps[1]); // Step 3 requires Step 2 to be completed
+          const isDisabled =
+          (index === 1 && !isCsvUploaded && !completedSteps[index]) || // Step 2 requires upload OR must be completed
+          (index === 2 && !completedSteps[1]); // Step 3 requires Step 2 to be completed
 
         return (
           <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,9 +25,10 @@ const Sidebar: React.FC<SidebarProps> = ({
   return (
     <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
       {steps.map((step, index) => {
-          const isDisabled =
-          (index === 1 && !isCsvUploaded && !completedSteps[index]) || // Step 2 requires upload OR must be completed
-          (index === 2 && !completedSteps[1]); // Step 3 requires Step 2 to be completed
+        const isDisabled =
+          !completedSteps[index] && // Allow completed steps to always be accessible
+          ((index === 1 && !isCsvUploaded) || // Step 2 requires CSV upload
+            (index === 2 && !completedSteps[1])); // Step 3 requires Step 2 to be completed
 
         return (
           <button
@@ -38,11 +39,11 @@ const Sidebar: React.FC<SidebarProps> = ({
               }
             }}
             className={`w-8 h-8 ${
-              index <= currentStep || (index === 1 && isCsvUploaded) || (index === 0 && isCsvUploaded) // Ensure Step 1 stays interactive and blue if a CSV is uploaded
+              completedSteps[index] || index === currentStep || (index === 0 && isCsvUploaded)
                 ? "cursor-pointer"
                 : "cursor-not-allowed"
             } ${
-              completedSteps[index] || index === currentStep || (index === 0 && isCsvUploaded) // Ensure Step 1 is blue if a CSV is uploaded
+              completedSteps[index] || index === currentStep || (index === 0 && isCsvUploaded)
                 ? "bg-blue-500"
                 : "bg-gray-300"
             }`}

--- a/src/components/UploadPage.tsx
+++ b/src/components/UploadPage.tsx
@@ -2,19 +2,15 @@
 
 import React, { useRef, useState, useContext } from "react";
 import Papa from "papaparse";
-import {
-  Box,
-  Modal,
-  Typography,
-  Button,
-} from "@mui/material";
+import { Box, Modal, Typography, Button } from "@mui/material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { CsvContext } from "../lib/CsvContext";
 
-const UploadPage: React.FC<{ onComplete: () => void; goToDataCleaningStep: () => void }> = ({
-  onComplete,
-  goToDataCleaningStep,
-}) => {
+const UploadPage: React.FC<{
+  onComplete: () => void;
+  goToDataCleaningStep: () => void;
+  resetSteps: () => void;
+}> = ({ onComplete, goToDataCleaningStep, resetSteps }) => {
   const { csvFile, setCsvFile, csvData, handleFileLoaded, clearFile } = useContext(CsvContext);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -36,27 +32,16 @@ const UploadPage: React.FC<{ onComplete: () => void; goToDataCleaningStep: () =>
       header: true,
       skipEmptyLines: true,
       complete: (results: { data: Record<string, unknown>[] }) => {
-        handleFileLoaded(file, results.data); // Set CSV file and data in context
-        setIsModalOpen(true); // Open modal with preview
+        handleFileLoaded(file, results.data);
+        setIsModalOpen(true);
       },
     });
   };
 
-  const loadFileAndProceed = () => {
-    setIsModalOpen(false); // Close modal
-    goToDataCleaningStep(); // Move to data cleaning step
-    onComplete(); // Mark this step as complete
+  const clearFileHandler = () => {
+    clearFile();
+    resetSteps(); // Reset the steps and state
   };
-
-  // Define columns for DataGrid
-  const columns: GridColDef[] = csvData.length
-    ? Object.keys(csvData[0]).map((key) => ({
-      field: key,
-      headerName: key,
-      flex: 1,
-      minWidth: 100,
-    }))
-    : [];
 
   return (
     <div>
@@ -64,7 +49,7 @@ const UploadPage: React.FC<{ onComplete: () => void; goToDataCleaningStep: () =>
       {csvFile ? (
         <div>
           <p>File uploaded: {csvFile.name}</p>
-          <Button onClick={clearFile} variant="outlined" color="secondary">
+          <Button onClick={clearFileHandler} variant="outlined" color="secondary">
             Clear File
           </Button>
         </div>
@@ -73,15 +58,34 @@ const UploadPage: React.FC<{ onComplete: () => void; goToDataCleaningStep: () =>
       )}
 
       <Modal open={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <Box sx={{ position: "absolute", top: "50%", left: "50%", transform: "translate(-50%, -50%)", width: "80%", bgcolor: "background.paper", boxShadow: 24, p: 4 }}>
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "80%",
+            bgcolor: "background.paper",
+            boxShadow: 24,
+            p: 4,
+          }}
+        >
           <Typography variant="h6" gutterBottom>
             CSV File Preview
           </Typography>
           <Box sx={{ height: 400, width: "100%" }}>
-            <DataGrid rows={csvData.map((row, index) => ({ id: index, ...row }))} columns={columns} />
+            <DataGrid
+              rows={csvData.map((row, index) => ({ id: index, ...row }))}
+              columns={Object.keys(csvData[0] || {}).map((key) => ({
+                field: key,
+                headerName: key,
+                flex: 1,
+                minWidth: 100,
+              }))}
+            />
           </Box>
-          <Button onClick={loadFileAndProceed} variant="contained" color="secondary" sx={{ mt: 2 }}>
-            Load
+          <Button onClick={goToDataCleaningStep} variant="contained" color="secondary" sx={{ mt: 2 }}>
+            Proceed
           </Button>
         </Box>
       </Modal>

--- a/src/components/VisualizePage.tsx
+++ b/src/components/VisualizePage.tsx
@@ -3,24 +3,22 @@
 import React, { useEffect } from "react";
 
 interface VisualizePageProps {
-  cleanedData: any;
+  cleanedData: any[];
   onComplete: () => void;
 }
 
 const VisualizePage: React.FC<VisualizePageProps> = ({ cleanedData, onComplete }) => {
-  // Mark this step as complete if cleanedData is available
   useEffect(() => {
-    if (cleanedData && onComplete) {
-      onComplete(); // Signal that this step is complete
+    if (cleanedData.length > 0) {
+      onComplete(); // Mark the step as complete
     }
-  }, [cleanedData, onComplete]);
+  }, [cleanedData]); // Only run when cleanedData changes
 
-  if (!cleanedData) {
+  if (!cleanedData || cleanedData.length === 0) {
     return <p>Please complete data cleaning before visualizing.</p>;
   }
 
   const handleGenerateReport = () => {
-    // Placeholder for generating and displaying visualizations or reports
     console.log("Generating report based on cleaned data:", cleanedData);
     alert("Report generated successfully!");
   };


### PR DESCRIPTION
fixes #25 

before: working yung step 1 and 2, but once you get to step 3, it breaks the validation, as well as sidebar cursor (shows disabled cursor but lets the user anyway (so crazy)) 

after/fix: 
- user can now go through all the steps, without breaking the navigation(hopefully). 
- once the user clears the csv, user can't jump steps anymore
- once user is done with a step, the step in the sidebar stays lit up/activated, indicating the user can go back to that step if they want

https://github.com/user-attachments/assets/23b41872-9caf-417b-a0be-31edc9963ac8


files changed:
- `Sidebar.tsx` added conditionals if step is not done, show disabled cursor for next step, also made the steps stay lit up if user is done with it
- replaced `loadFileAndProceed` with `goToDataCleaningStep`
- in `UploadPage.tsx` removed GridColDef[] (for some reason????) but same lang naman yung output

note:
- validation from step 2 to step 3 is only if "Clean Data" button is clicked, since no implementation for clean data is available yet
