### PR TITLE
[feat] Rework Upload Page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,11 @@ const steps: Step[] = [
 
 const HomeContent: React.FC = () => {
   const [currentStep, setCurrentStep] = useState<number>(0);
-  const [completedSteps, setCompletedSteps] = useState<boolean[]>([false, false, false]);
+  const [completedSteps, setCompletedSteps] = useState<boolean[]>([
+    false,
+    false,
+    false,
+  ]);
 
   // Move to the next step
   const handleNext = () => {
@@ -54,7 +58,7 @@ const HomeContent: React.FC = () => {
   const StepComponent = steps[currentStep].component;
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-screen w-screen max-w-screen max-h-screen overflow-clip">
       <div className="flex flex-row w-full pb-1 items-center space-x-4 px-4 bg-[#d9d9d9]">
         <img src="/prismicon.ico" alt="logo" className="w-16 h-16 my-4" />
         <div className="flex flex-col items-start space-y-1 my-1 w-full">
@@ -63,11 +67,15 @@ const HomeContent: React.FC = () => {
             <span>Home</span>
             <span>Help</span>
           </div>
-          <Ribbon currentStep={currentStep} />
+          <Ribbon
+            currentStep={currentStep}
+            setCurrentStep={setCurrentStep}
+            setCompletedSteps={setCompletedSteps}
+          />
         </div>
       </div>
 
-      <div className="flex flex-row h-full">
+      <div className="flex flex-row h-full max-h-full">
         <Sidebar
           steps={steps}
           currentStep={currentStep}
@@ -75,21 +83,12 @@ const HomeContent: React.FC = () => {
           completedSteps={completedSteps}
         />
 
-        <div className="flex flex-col h-full w-full p-4">
+        <div className="flex flex-col max-h-30 max-w-full p-4">
           <StepComponent
-            setCurrentStep={setCurrentStep} 
-            onComplete={completeCurrentStep} 
+            setCurrentStep={setCurrentStep}
+            onComplete={completeCurrentStep}
             setCompletedSteps={setCompletedSteps}
           />
-
-          <div className="flex space-x-4 mt-8">
-            <button onClick={handleBack} disabled={currentStep === 0} className="px-4 py-2 bg-gray-300 rounded">
-              Back
-            </button>
-            <button onClick={handleNext} disabled={!completedSteps[currentStep]} className="px-4 py-2 bg-blue-500 text-white rounded">
-              {currentStep === steps.length - 1 ? "Finish" : "Next"}
-            </button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,7 @@ const HomeContent: React.FC = () => {
         </div>
       </div>
 
-      <div className="flex flex-row h-full max-h-full">
+      <div className="flex flex-row h-full max-h-full max-w-full">
         <Sidebar
           steps={steps}
           currentStep={currentStep}
@@ -83,7 +83,7 @@ const HomeContent: React.FC = () => {
           completedSteps={completedSteps}
         />
 
-        <div className="flex flex-col max-h-30 max-w-full p-4">
+        <div className="flex flex-col max-h-full max-w-full p-4">
           <StepComponent
             setCurrentStep={setCurrentStep}
             onComplete={completeCurrentStep}

--- a/src/components/Ribbon.tsx
+++ b/src/components/Ribbon.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { Skeleton } from "@mui/material";
-import React from "react";
+import React, { useContext } from "react";
+import { CsvContext } from "../lib/CsvContext";
 
 interface RibbonProps {
   currentStep: number;
+  setCurrentStep: (step: number) => void;
+  setCompletedSteps: (steps: boolean[]) => void;
 }
 
 interface RibbonButtonProps {
@@ -16,14 +19,23 @@ interface RibbonButtonProps {
 
 const RibbonButton: React.FC<RibbonButtonProps> = ({ label, onClick }) => {
   return (
-    <div className="flex flex-col w-16 space-y-1 items-center">
+    <div
+      onClick={onClick}
+      className="flex flex-col w-16 space-y-1 items-center"
+    >
       <div className="h-10 aspect-square bg-slate-500" />
       <span className="text-xs text-wrap text-center w-max-full">{label}</span>
     </div>
   );
 };
 
-const Ribbon: React.FC<RibbonProps> = ({ currentStep }) => {
+const Ribbon: React.FC<RibbonProps> = ({
+  currentStep,
+  setCurrentStep,
+  setCompletedSteps,
+}) => {
+  const { csvData, clearFile } = useContext(CsvContext);
+
   const temp = () => {};
 
   const buttonSetsLeft = [
@@ -48,8 +60,23 @@ const Ribbon: React.FC<RibbonProps> = ({ currentStep }) => {
   const buttonSetsRight = [
     // Upload
     [
-      <RibbonButton key={0} label="Clear" onClick={temp} />,
-      <RibbonButton key={1} label="Proceed" onClick={temp} />,
+      <RibbonButton
+        key={0}
+        label="Clear"
+        onClick={() => {
+          clearFile();
+          setCompletedSteps([false, false, false]);
+          setCurrentStep(0);
+        }}
+      />,
+      <RibbonButton
+        key={1}
+        label="Proceed"
+        onClick={() => {
+          setCompletedSteps([true, false, false]);
+          setCurrentStep(1);
+        }}
+      />,
     ],
 
     // Clean

--- a/src/components/Ribbon.tsx
+++ b/src/components/Ribbon.tsx
@@ -15,15 +15,22 @@ interface RibbonButtonProps {
   // icon: React.ReactNode;
   label: string;
   onClick: () => void;
+  enabled: boolean;
 }
 
-const RibbonButton: React.FC<RibbonButtonProps> = ({ label, onClick }) => {
+const RibbonButton: React.FC<RibbonButtonProps> = ({
+  label,
+  onClick,
+  enabled,
+}) => {
   return (
     <div
       onClick={onClick}
       className="flex flex-col w-16 space-y-1 items-center"
     >
-      <div className="h-10 aspect-square bg-slate-500" />
+      <div
+        className={`h-10 aspect-square ${enabled ? "bg-blue-500" : "bg-slate-500"}`}
+      />
       <span className="text-xs text-wrap text-center w-max-full">{label}</span>
     </div>
   );
@@ -44,16 +51,46 @@ const Ribbon: React.FC<RibbonProps> = ({
 
     // Clean
     [
-      <RibbonButton key={0} label="Remove Duplicate" onClick={temp} />,
-      <RibbonButton key={1} label="Remove Invalid" onClick={temp} />,
-      <RibbonButton key={2} label="Remove Empty" onClick={temp} />,
+      <RibbonButton
+        key={0}
+        label="Remove Duplicate"
+        onClick={temp}
+        enabled={true}
+      />,
+      <RibbonButton
+        key={1}
+        label="Remove Invalid"
+        onClick={temp}
+        enabled={true}
+      />,
+      <RibbonButton
+        key={2}
+        label="Remove Empty"
+        onClick={temp}
+        enabled={true}
+      />,
     ],
 
     // Visualize
     [
-      <RibbonButton key={0} label="Add a Chart" onClick={temp} />,
-      <RibbonButton key={1} label="Add a Textbox" onClick={temp} />,
-      <RibbonButton key={2} label="Add Controls" onClick={temp} />,
+      <RibbonButton
+        key={0}
+        label="Add a Chart"
+        onClick={temp}
+        enabled={true}
+      />,
+      <RibbonButton
+        key={1}
+        label="Add a Textbox"
+        onClick={temp}
+        enabled={true}
+      />,
+      <RibbonButton
+        key={2}
+        label="Add Controls"
+        onClick={temp}
+        enabled={true}
+      />,
     ],
   ];
 
@@ -68,6 +105,7 @@ const Ribbon: React.FC<RibbonProps> = ({
           setCompletedSteps([false, false, false]);
           setCurrentStep(0);
         }}
+        enabled={csvData.length > 0}
       />,
       <RibbonButton
         key={1}
@@ -76,19 +114,25 @@ const Ribbon: React.FC<RibbonProps> = ({
           setCompletedSteps([true, false, false]);
           setCurrentStep(1);
         }}
+        enabled={csvData.length > 0}
       />,
     ],
 
     // Clean
     [
-      <RibbonButton key={0} label="Delete Rows" onClick={temp} />,
-      <RibbonButton key={1} label="Proceed" onClick={temp} />,
+      <RibbonButton
+        key={0}
+        label="Delete Rows"
+        onClick={temp}
+        enabled={true}
+      />,
+      <RibbonButton key={1} label="Proceed" onClick={temp} enabled={true} />,
     ],
 
     // Visualize
     [
-      <RibbonButton key={0} label="Preview" onClick={temp} />,
-      <RibbonButton key={1} label="Print" onClick={temp} />,
+      <RibbonButton key={0} label="Preview" onClick={temp} enabled={true} />,
+      <RibbonButton key={1} label="Print" onClick={temp} enabled={true} />,
     ],
   ];
 

--- a/src/components/Ribbon.tsx
+++ b/src/components/Ribbon.tsx
@@ -23,16 +23,16 @@ const RibbonButton: React.FC<RibbonButtonProps> = ({
   onClick,
   enabled,
 }) => {
-  return (
+  return enabled ? (
     <div
       onClick={onClick}
       className="flex flex-col w-16 space-y-1 items-center"
     >
-      <div
-        className={`h-10 aspect-square ${enabled ? "bg-blue-500" : "bg-slate-500"}`}
-      />
+      <div className="h-10 aspect-square bg-slate-500" />
       <span className="text-xs text-wrap text-center w-max-full">{label}</span>
     </div>
+  ) : (
+    <></>
   );
 };
 

--- a/src/components/Ribbon.tsx
+++ b/src/components/Ribbon.tsx
@@ -17,7 +17,7 @@ interface RibbonButtonProps {
 const RibbonButton: React.FC<RibbonButtonProps> = ({ label, onClick }) => {
   return (
     <div className="flex flex-col w-16 space-y-1 items-center">
-      <div className="h-16 aspect-square bg-slate-500" />
+      <div className="h-10 aspect-square bg-slate-500" />
       <span className="text-xs text-wrap text-center w-max-full">{label}</span>
     </div>
   );
@@ -26,7 +26,7 @@ const RibbonButton: React.FC<RibbonButtonProps> = ({ label, onClick }) => {
 const Ribbon: React.FC<RibbonProps> = ({ currentStep }) => {
   const temp = () => {};
 
-  const buttonSets = [
+  const buttonSetsLeft = [
     // Upload
     [],
 
@@ -45,9 +45,34 @@ const Ribbon: React.FC<RibbonProps> = ({ currentStep }) => {
     ],
   ];
 
+  const buttonSetsRight = [
+    // Upload
+    [
+      <RibbonButton key={0} label="Clear" onClick={temp} />,
+      <RibbonButton key={1} label="Proceed" onClick={temp} />,
+    ],
+
+    // Clean
+    [
+      <RibbonButton key={0} label="Delete Rows" onClick={temp} />,
+      <RibbonButton key={1} label="Proceed" onClick={temp} />,
+    ],
+
+    // Visualize
+    [
+      <RibbonButton key={0} label="Preview" onClick={temp} />,
+      <RibbonButton key={1} label="Print" onClick={temp} />,
+    ],
+  ];
+
   return (
-    <div className="flex flex-row h-20 space-x-2">
-      {buttonSets[currentStep].map((button) => button)}
+    <div className="flex flex-row h-20 w-full justify-between">
+      <div className="flex flex-row space-x-2">
+        {buttonSetsLeft[currentStep].map((button) => button)}
+      </div>
+      <div className="flex flex-row space-x-2">
+        {buttonSetsRight[currentStep].map((button) => button)}
+      </div>
     </div>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,12 +21,11 @@ const Sidebar: React.FC<SidebarProps> = ({
   setCurrentStep,
   completedSteps,
 }) => {
-
   const { csvFile } = useContext(CsvContext);
   const isCsvUploaded = !!csvFile;
 
   return (
-    <div className="flex flex-col space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
+    <div className="flex flex-col h-full space-y-2 p-2 outline outline-1 outline-[#d9d9d9]">
       {steps.map((step, index) => {
         const isDisabled =
           !completedSteps[index] && // Allow completed steps to always be accessible
@@ -43,7 +42,9 @@ const Sidebar: React.FC<SidebarProps> = ({
             className={`w-8 h-8 ${
               !isDisabled ? "cursor-pointer" : "cursor-not-allowed"
             } ${
-              completedSteps[index] || index === currentStep || (index === 0 && isCsvUploaded)
+              completedSteps[index] ||
+              index === currentStep ||
+              (index === 0 && isCsvUploaded)
                 ? "bg-blue-500"
                 : "bg-gray-300"
             }`}

--- a/src/components/UploadPage.tsx
+++ b/src/components/UploadPage.tsx
@@ -67,11 +67,11 @@ const UploadPage: React.FC<UploadPageProps> = ({
       : [];
 
   return (
-    <div className="max-h-full max-w-full pb-28">
+    <div className="max-h-full max-w-full pb-28 pr-11">
       {csvFile ? (
         <div className="w-full h-full max-w-full max-h-full">
           <DataGrid
-            className="w-full"
+            className="max-w-full"
             rows={csvData.map((row, index) => ({ id: index, ...row }))}
             columns={columns}
           />

--- a/src/components/UploadPage.tsx
+++ b/src/components/UploadPage.tsx
@@ -9,7 +9,7 @@ import { CsvContext } from "../lib/CsvContext";
 interface UploadPageProps {
   onComplete: () => void;
   setCurrentStep: (step: number) => void;
-  setCompletedSteps: React.Dispatch<React.SetStateAction<boolean[]>>; 
+  setCompletedSteps: React.Dispatch<React.SetStateAction<boolean[]>>;
 }
 
 const UploadPage: React.FC<UploadPageProps> = ({
@@ -17,8 +17,13 @@ const UploadPage: React.FC<UploadPageProps> = ({
   setCurrentStep,
   setCompletedSteps,
 }) => {
-  const { csvFile, setCsvFile, csvData, handleFileLoaded, clearFile } = useContext(CsvContext);
+  const { csvFile, setCsvFile, csvData, handleFileLoaded, clearFile } =
+    useContext(CsvContext);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [uploadedData, setUploadedData] = useState<Record<string, unknown>[]>(
+    [],
+  );
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -27,20 +32,24 @@ const UploadPage: React.FC<UploadPageProps> = ({
         header: true,
         skipEmptyLines: true,
         complete: (results: { data: Record<string, unknown>[] }) => {
-          handleFileLoaded(file, results.data);
+          //handleFileLoaded(file, results.data);
+          setFile(file);
+          setUploadedData(results.data);
           setIsModalOpen(true);
-          onComplete();
         },
       });
     }
   };
 
-  const handleClearFile = () => {
-    clearFile(); // Clears file data from CsvContext
-    setCompletedSteps([false, false, false]); // Resets all step completions
-    setCurrentStep(0); // Go back to the Upload step
+  const handleFileLoad = () => {
+    if (file && uploadedData) {
+      handleFileLoaded(file, uploadedData);
+      setIsModalOpen(false);
+      onComplete();
+    }
   };
 
+  // Get columns of csvData or uploadedData depending on which is available
   const columns: GridColDef[] = csvData.length
     ? Object.keys(csvData[0]).map((key) => ({
         field: key,
@@ -48,31 +57,60 @@ const UploadPage: React.FC<UploadPageProps> = ({
         flex: 1,
         minWidth: 100,
       }))
-    : [];
+    : uploadedData.length
+      ? Object.keys(uploadedData[0]).map((key) => ({
+          field: key,
+          headerName: key,
+          flex: 1,
+          minWidth: 100,
+        }))
+      : [];
 
   return (
-    <div>
-      <p>Upload CSV File</p>
+    <div className="max-h-full max-w-full pb-28">
       {csvFile ? (
-        <div>
-          <p>File uploaded: {csvFile.name}</p>
-          <Button onClick={handleClearFile} variant="outlined" color="secondary">
-            Clear File
-          </Button>
+        <div className="w-full h-full max-w-full max-h-full">
+          <DataGrid
+            className="w-full"
+            rows={csvData.map((row, index) => ({ id: index, ...row }))}
+            columns={columns}
+          />
         </div>
       ) : (
         <input type="file" accept=".csv" onChange={handleFileUpload} />
       )}
 
       <Modal open={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <Box sx={{ position: "absolute", top: "50%", left: "50%", transform: "translate(-50%, -50%)", width: "80%", bgcolor: "background.paper", boxShadow: 24, p: 4 }}>
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "80%",
+            bgcolor: "background.paper",
+            boxShadow: 24,
+            p: 4,
+          }}
+        >
           <Typography variant="h6" gutterBottom>
             CSV File Preview
           </Typography>
           <Box sx={{ height: 400, width: "100%" }}>
-            <DataGrid rows={csvData.map((row, index) => ({ id: index, ...row }))} columns={columns} />
+            <DataGrid
+              rows={uploadedData.map((row, index) => ({
+                id: index,
+                ...row,
+              }))}
+              columns={columns}
+            />
           </Box>
-          <Button onClick={() => setCurrentStep(1)} variant="contained" color="secondary" sx={{ mt: 2 }}>
+          <Button
+            onClick={() => handleFileLoad()}
+            variant="contained"
+            color="secondary"
+            sx={{ mt: 2 }}
+          >
             Load
           </Button>
         </Box>


### PR DESCRIPTION
Closes #39 

## Changes
- Separates "uploading" and "loading" logic. "Uploading" is when you just first upload a file from the input dialog, "Loading' is when the load button in the modal is clicked (This is to avoid updating the main upload page screen before the load button is clicked).
- Fully dynamic data grid view that fills the screen but doesn't go out of scrolling bounds
- Divides the ribbon into two button sets: left and right
- Implements the `onClick` property in the ribbon buttons
- Implements an `enabled` property for ribbon buttons that hides them when set to false.

## Preview
https://github.com/user-attachments/assets/0479e3a5-c520-4ded-b592-c4a8bf5f6e32

