### PR TITLE
[feat] Visualization Page Framework

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import CleanPage from "../components/CleanPage";
 import VisualizePage from "../components/VisualizePage";
 import { CsvContextProvider, CsvContext } from "../lib/CsvContext";
 import { StepContextProvider, useStepContext } from "../lib/StepContext";
+import { ChartContextProvider } from "../lib/ChartContext";
 
 type Step = {
   name: string;
@@ -43,11 +44,11 @@ const HomeContent: React.FC = () => {
         </div>
       </div>
       {/* Main Content */}
-      <div className="flex h-screen bg-primary-main text-neutral-white-10">
+      <div className="flex h-full max-h-full bg-primary-main text-neutral-white-10">
         {/* Sidebar */}
         <Sidebar steps={steps} />
         {/* Step Component */}
-        <div className="flex flex-col flex-grow p-6 overflow-hidden">
+        <div className="flex flex-col flex-grow p-6 max-h-full overflow-hidden">
           <StepComponent />
         </div>
       </div>
@@ -60,7 +61,9 @@ export default function Home() {
   return (
     <CsvContextProvider>
       <StepContextProvider>
-        <HomeContent />
+        <ChartContextProvider>
+          <HomeContent />
+        </ChartContextProvider>
       </StepContextProvider>
     </CsvContextProvider>
   );

--- a/src/components/VisualizePage.tsx
+++ b/src/components/VisualizePage.tsx
@@ -27,17 +27,7 @@ const VisualizePage: React.FC = () => {
     alert("Report generated successfully!");
   };
 
-  return (
-    <div>
-      <h2>Visualization and Reporting</h2>
-      <button
-        onClick={handleReportGeneration}
-        className="mt-4 px-4 py-2 bg-green-500 text-white rounded"
-      >
-        Generate Report
-      </button>
-    </div>
-  );
+  return <div></div>;
 };
 
 export default VisualizePage;

--- a/src/components/VisualizePage.tsx
+++ b/src/components/VisualizePage.tsx
@@ -3,9 +3,11 @@
 import React, { useEffect, useContext, useState } from "react";
 import { CsvContext } from "../lib/CsvContext";
 import { useStepContext } from "../lib/StepContext";
+import { useChartContext } from "../lib/ChartContext";
 
 const VisualizePage: React.FC = () => {
   const { csvData } = useContext(CsvContext);
+  const { figures } = useChartContext();
   const { completeCurrentStep } = useStepContext();
   const [isCompleteNotified, setIsCompleteNotified] = useState(false);
 
@@ -22,12 +24,15 @@ const VisualizePage: React.FC = () => {
     return <p>Please complete data cleaning before visualizing.</p>;
   }
 
-  const handleReportGeneration = () => {
-    console.log("Generating report based on cleaned data:", csvData);
-    alert("Report generated successfully!");
-  };
-
-  return <div></div>;
+  return (
+    <div className="h-full w-full max-h-full max-w-full">
+      <div className="flex flex-col space-y-2 justify-center">
+        {figures.map((figure, index) => (
+          <React.Fragment key={index}>{figure}</React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default VisualizePage;

--- a/src/components/ribbon/RibbonButton.tsx
+++ b/src/components/ribbon/RibbonButton.tsx
@@ -6,6 +6,7 @@ interface RibbonButtonProps {
   onClick: () => void;
   enabled: boolean;
   tooltip: string;
+  ref?: React.RefObject<HTMLDivElement>;
 }
 
 const RibbonButton: React.FC<RibbonButtonProps> = ({
@@ -13,11 +14,13 @@ const RibbonButton: React.FC<RibbonButtonProps> = ({
   onClick,
   enabled,
   tooltip,
+  ref,
 }) => {
   return enabled ? (
     <Tooltip title={tooltip} arrow>
       <div
         onClick={onClick}
+        ref={ref}
         className="flex flex-col w-20 space-y-1 items-center cursor-pointer p-2 rounded-md"
       >
         <div className="h-10 w-10 flex items-center justify-center text-white">

--- a/src/components/ribbon/VisualizeRibbon.tsx
+++ b/src/components/ribbon/VisualizeRibbon.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useContext, useRef } from "react";
 import RibbonButton from "./RibbonButton";
+import { CreateBarChart } from "./charts/BarChartModals";
 import { CsvContext } from "../../lib/CsvContext";
-import { useStepContext } from "../../lib/StepContext";
+import { useChartContext } from "../../lib/ChartContext";
 
 // Material UI
 import BarChartIcon from "@mui/icons-material/BarChart";
@@ -21,12 +22,18 @@ interface VisualizeRibbonProps {
 interface PopoverButtonProps {
   Icon: React.ElementType;
   label: string;
+  onClick?: () => void;
 }
 
 // Static Components
-const PopoverButton: React.FC<PopoverButtonProps> = ({ Icon, label }) => {
+const PopoverButton: React.FC<PopoverButtonProps> = ({
+  Icon,
+  label,
+  onClick,
+}) => {
   return (
     <div
+      onClick={onClick}
       className="w-24 h-24 rounded-md flex flex-col justify-center items-center outline
         text-[#313154] hover:text-white
         bg-[#b4b4b4]
@@ -45,7 +52,9 @@ const VisualizeRibbon: React.FC<VisualizeRibbonProps> = ({
 }) => {
   // Initialization
   const addChartRef = useRef(null);
+  const { addFigure } = useChartContext();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isBarChartInvoked, setIsBarChartInvoked] = useState(false);
 
   // Components
   const AddChartPopover: React.FC = () => {
@@ -65,7 +74,14 @@ const VisualizeRibbon: React.FC<VisualizeRibbonProps> = ({
       >
         <div className="flex flex-col space-y-6 p-6 bg-white rounded-xl shadow-md items-center">
           <div className="flex flex-row space-x-6">
-            <PopoverButton Icon={BarChartIcon} label="Bar Chart" />
+            <PopoverButton
+              Icon={BarChartIcon}
+              label="Bar Chart"
+              onClick={() => {
+                setIsBarChartInvoked(true);
+                setIsPopoverOpen(false);
+              }}
+            />
             <PopoverButton Icon={PieChartIcon} label="Pie Chart" />
           </div>
           <div className="flex flex-row space-x-6">
@@ -105,7 +121,13 @@ const VisualizeRibbon: React.FC<VisualizeRibbonProps> = ({
       <RibbonButton
         key={1}
         Icon={TextFieldsIcon}
-        onClick={() => {}}
+        onClick={() => {
+          addFigure(
+            <div className="flex flex-row bg-white justify-center items-center w-64 h-32">
+              <p className="text-sm">Text</p>
+            </div>,
+          );
+        }}
         enabled={true}
         tooltip="Add a Textbox: Annotate your visualization"
       />,
@@ -135,6 +157,10 @@ const VisualizeRibbon: React.FC<VisualizeRibbonProps> = ({
       {left ? VisualizeButtonSet.left.map((button) => button) : null}
       {right ? VisualizeButtonSet.right.map((button) => button) : null}
       <AddChartPopover />
+      <CreateBarChart
+        invoked={isBarChartInvoked}
+        setInvoked={setIsBarChartInvoked}
+      />
     </>
   );
 };

--- a/src/components/ribbon/VisualizeRibbon.tsx
+++ b/src/components/ribbon/VisualizeRibbon.tsx
@@ -1,18 +1,84 @@
-import React, { useContext } from "react";
+import React, { useState, useContext, useRef } from "react";
 import RibbonButton from "./RibbonButton";
 import { CsvContext } from "../../lib/CsvContext";
 import { useStepContext } from "../../lib/StepContext";
 
 // Material UI
 import BarChartIcon from "@mui/icons-material/BarChart";
+import PieChartIcon from "@mui/icons-material/PieChart";
+import ShowChartIcon from "@mui/icons-material/ShowChart";
+import StackedLineChartIcon from "@mui/icons-material/StackedLineChart";
+import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
 import TextFieldsIcon from "@mui/icons-material/TextFields";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import Popover from "@mui/material/Popover";
 
-const VisualizeRibbon: React.FC<{ left?: boolean; right?: boolean }> = ({
+// Interfaces
+interface VisualizeRibbonProps {
+  left?: boolean;
+  right?: boolean;
+}
+interface PopoverButtonProps {
+  Icon: React.ElementType;
+  label: string;
+}
+
+// Static Components
+const PopoverButton: React.FC<PopoverButtonProps> = ({ Icon, label }) => {
+  return (
+    <div
+      className="w-24 h-24 rounded-md flex flex-col justify-center items-center outline
+        text-[#313154] hover:text-white
+        bg-[#b4b4b4]
+        hover:bg-[#545469]
+        outline-[#545469]"
+    >
+      <Icon className="text-6xl" />
+      <p className="text-sm">{label}</p>
+    </div>
+  );
+};
+
+const VisualizeRibbon: React.FC<VisualizeRibbonProps> = ({
   left = false,
   right = false,
 }) => {
   // Initialization
+  const addChartRef = useRef(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  // Components
+  const AddChartPopover: React.FC = () => {
+    return (
+      <Popover
+        open={isPopoverOpen}
+        onClose={() => setIsPopoverOpen(false)}
+        anchorEl={addChartRef.current}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        <div className="flex flex-col space-y-6 p-6 bg-white rounded-xl shadow-md items-center">
+          <div className="flex flex-row space-x-6">
+            <PopoverButton Icon={BarChartIcon} label="Bar Chart" />
+            <PopoverButton Icon={PieChartIcon} label="Pie Chart" />
+          </div>
+          <div className="flex flex-row space-x-6">
+            <PopoverButton Icon={ShowChartIcon} label="Line Chart" />
+            <PopoverButton Icon={StackedLineChartIcon} label="Area Chart" />
+          </div>
+          <div className="flex flex-row space-x-6">
+            <PopoverButton Icon={ScatterPlotIcon} label="Scatter Chart" />
+          </div>
+        </div>
+      </Popover>
+    );
+  };
 
   // Functions
 
@@ -26,9 +92,13 @@ const VisualizeRibbon: React.FC<{ left?: boolean; right?: boolean }> = ({
     left: [
       // Left Ribbon Buttons
       <RibbonButton
+        ref={addChartRef}
         key={0}
         Icon={BarChartIcon}
-        onClick={() => {}}
+        onClick={() => {
+          setIsPopoverOpen(true);
+          console.log("Adding a chart...");
+        }}
         enabled={true}
         tooltip="Add a Chart: Visualize your data with a chart"
       />,
@@ -64,6 +134,7 @@ const VisualizeRibbon: React.FC<{ left?: boolean; right?: boolean }> = ({
     <>
       {left ? VisualizeButtonSet.left.map((button) => button) : null}
       {right ? VisualizeButtonSet.right.map((button) => button) : null}
+      <AddChartPopover />
     </>
   );
 };

--- a/src/components/ribbon/charts/BarChartModals.tsx
+++ b/src/components/ribbon/charts/BarChartModals.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import StepModal from "./StepModal";
+import { useChartContext } from "@/lib/ChartContext";
+
+interface CreateBarChartProps {
+  invoked: boolean;
+  setInvoked: (invoked: boolean) => void;
+}
+
+export const CreateBarChart: React.FC<CreateBarChartProps> = ({
+  invoked,
+  setInvoked,
+}) => {
+  const { addFigure } = useChartContext();
+
+  const [xAxis, setXAxis] = useState("");
+  const [yAxis, setYAxis] = useState("");
+  const [yAxisModalOpen, setYAxisModalOpen] = useState(false);
+
+  return (
+    <>
+      <StepModal
+        header="Please select the columns for the x-axis"
+        open={invoked}
+        onClose={() => {
+          setInvoked(false);
+        }}
+        onConfirm={() => {
+          setInvoked(false);
+          setYAxisModalOpen(true);
+        }}
+        setChoice={setXAxis}
+        mustBeNumber
+      />
+
+      <StepModal
+        header="Please select the columns for the y-axis"
+        open={yAxisModalOpen}
+        onClose={() => {
+          setYAxisModalOpen(false);
+        }}
+        onConfirm={() => {
+          setYAxisModalOpen(false);
+          addFigure(
+            <div className="flex flex-col items-center justify-center h-64 w-64 bg-white">
+              <p className="text-lg bold">Bar Chart!</p>
+            </div>,
+          );
+        }}
+        setChoice={setYAxis}
+      />
+    </>
+  );
+};

--- a/src/components/ribbon/charts/BarChartModals.tsx
+++ b/src/components/ribbon/charts/BarChartModals.tsx
@@ -20,7 +20,7 @@ export const CreateBarChart: React.FC<CreateBarChartProps> = ({
   return (
     <>
       <StepModal
-        header="Please select the columns for the x-axis"
+        header="Please select a column for the x-axis"
         open={invoked}
         onClose={() => {
           setInvoked(false);
@@ -34,7 +34,7 @@ export const CreateBarChart: React.FC<CreateBarChartProps> = ({
       />
 
       <StepModal
-        header="Please select the columns for the y-axis"
+        header="Please select a column for the y-axis"
         open={yAxisModalOpen}
         onClose={() => {
           setYAxisModalOpen(false);

--- a/src/components/ribbon/charts/StepModal.tsx
+++ b/src/components/ribbon/charts/StepModal.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useContext } from "react";
+import { Modal, Box, Button, Checkbox, Select, MenuItem } from "@mui/material";
+import { DataGrid, GridColDef, GridColumnHeaderParams } from "@mui/x-data-grid";
+import { CsvContext } from "../../../lib/CsvContext";
+
+function determineValueType(str: string) {
+  // Check if the string is a numerical value
+  const num = parseFloat(str);
+  if (!isNaN(num)) {
+    if (num >= 1000 && num <= 9999) {
+      // assume it's a year if it's a 4-digit number
+      return "date";
+    } else {
+      return "number";
+    }
+  }
+
+  // Check if the string is a date value
+  const date = new Date(str);
+  if (!isNaN(date.getTime())) {
+    return "date";
+  }
+
+  // If none of the above, assume it's a word value
+  return "string";
+}
+
+interface StepModalProps {
+  header: string;
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  setChoice: (choice: string) => void;
+  mustBeNumber?: boolean;
+  optional?: boolean;
+}
+
+const StepModal: React.FC<StepModalProps> = ({
+  header,
+  open,
+  onClose,
+  onConfirm,
+  setChoice,
+  mustBeNumber = false,
+  optional = false,
+}) => {
+  const { csvData } = useContext(CsvContext);
+  const [metric, setMetric] = useState("count");
+  const columnSelection = Object.keys(csvData[0]).map((key, index) => {
+    const [selected, setSelected] = useState(false);
+
+    return {
+      index: index,
+      name: key,
+      type: determineValueType(String(csvData[0][key])),
+      selected: selected,
+      setSelected: setSelected,
+    };
+  });
+
+  const select = (index: number) => {
+    // Deselect all columns except the selected one
+    Object.keys(csvData[0])
+      .filter((_, i) => i !== index)
+      .map((_, i) => {
+        columnSelection[i].setSelected(false);
+      });
+    // Toggle the selected column
+    columnSelection[index].setSelected(!columnSelection[index].selected);
+  };
+
+  const columns: GridColDef[] = csvData.length
+    ? Object.keys(csvData[0]).map((key, index) => ({
+        field: key,
+        headerName: key,
+        flex: 1,
+        minWidth: 150,
+        renderHeader: (params: GridColumnHeaderParams) => (
+          <div
+            onClick={() => select(index)}
+            className="flex flex-row space-x-2 items-center"
+          >
+            <Checkbox
+              checked={columnSelection[index].selected}
+              onChange={() => {
+                select(index);
+              }}
+            />
+
+            {params.field}
+          </div>
+        ),
+      }))
+    : [];
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: "80%",
+          bgcolor: "background.paper",
+          border: "2px solid #000",
+          boxShadow: 24,
+          p: 4,
+        }}
+      >
+        <div className="flex flex-row w-full justify-center mb-4">
+          <span className="text-2xl font-bold">{header}</span>
+        </div>
+        <Box sx={{ height: 400, width: "100%" }}>
+          <DataGrid
+            rows={csvData.map((row, index) => ({
+              id: index,
+              ...row,
+            }))}
+            columns={columns}
+            disableColumnMenu={true}
+            disableColumnSorting={true}
+          />
+        </Box>
+        <div className="flex flex-row space-x-4 justify-end mt-4">
+          <Button
+            onClick={() => {
+              columnSelection
+                .filter((col) => col.selected)
+                .map((col) => {
+                  col.setSelected(false);
+                  setChoice(col.name);
+                });
+              onConfirm();
+            }}
+            color="primary"
+            variant="contained"
+          >
+            Confirm
+          </Button>
+          <Button onClick={onClose} color="secondary" variant="contained">
+            Cancel
+          </Button>
+        </div>
+      </Box>
+    </Modal>
+  );
+};
+
+export default StepModal;

--- a/src/lib/ChartContext.tsx
+++ b/src/lib/ChartContext.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+type ChartContextType = {
+  figures: ReactNode[];
+  addFigure: (figure: ReactNode) => void;
+  removeFigure: (index: number) => void;
+};
+
+export const ChartContext = createContext<ChartContextType | undefined>(
+  undefined,
+);
+
+export const ChartContextProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [figures, setFigures] = useState<ReactNode[]>([]);
+
+  const addFigure = (figure: ReactNode) => {
+    setFigures((prevFigures) => [...prevFigures, figure]);
+  };
+
+  const removeFigure = (index: number) => {
+    setFigures((prevFigures) => prevFigures.filter((_, i) => i !== index));
+  };
+
+  return (
+    <ChartContext.Provider value={{ figures, addFigure, removeFigure }}>
+      {children}
+    </ChartContext.Provider>
+  );
+};
+
+export const useChartContext = () => {
+  const context = useContext(ChartContext);
+  if (!context) {
+    throw new Error(
+      "useChartContext must be used within a ChartContextProvider",
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
## Changes:
### ChartContext
- context for interacting with the Visualization page
- reference `figure` to get list of figures
- use `addFigure` and `removeFigure` to modify figure list

### StepModal
- modal component that allows you to choose a column from the uploaded data
- use `setChoice` to get chosen value
- use `onConfirm` and `onClose` to add additional functionality to the confirm and close buttons
- set `optional` if choice can be skipped (not yet implemented)
- set `mustBeNumber` to convert columns with string values to either count, average, min, max, etc. the string values (not yet implemented)

### Framework
- for every chart type, create a `{ChartType}Modals.tsx` and define the needed `StepModal` components there. See `BarChartModals.tsx` as an example

https://github.com/user-attachments/assets/c4c8a92c-a87e-4979-8cbb-46dec99940f7

