### PR TITLE
Persistent Chart Insights

### DIFF
--- a/src/components/charts/Bar.tsx
+++ b/src/components/charts/Bar.tsx
@@ -166,11 +166,12 @@ export const BarChart: React.FC<BarProps> = ({
   // Close modal
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setModalContent(null); // Clear content when modal closes
   };
 
   // Fetch insights from the API
   const fetchInsights = async () => {
+    if (modalContent) return; // Don't fetch if there are insights already
+
     setIsLoading(true); // Start loading
     setModalContent(null); // Clear previous content
 

--- a/src/components/charts/Bubble.tsx
+++ b/src/components/charts/Bubble.tsx
@@ -219,11 +219,12 @@ export const BubbleChart: React.FC<BubbleChartProps> = ({
   // Close modal
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setModalContent(null); // Clear content when modal closes
   };
 
   // Fetch insights from the API
   const fetchInsights = async () => {
+    if (modalContent) return; // Don't fetch if there are insights already
+
     setIsLoading(true); // Start loading
     setModalContent(null); // Clear previous content
 

--- a/src/components/charts/Donut.tsx
+++ b/src/components/charts/Donut.tsx
@@ -133,11 +133,12 @@ export const DonutChart: React.FC<DonutProps> = ({ columnInitial, id }) => {
   // Close modal
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setModalContent(null); // Clear content when modal closes
   };
 
   // Fetch insights from the API
   const fetchInsights = async () => {
+    if (modalContent) return; // Don't fetch if there are insights already
+
     setIsLoading(true); // Start loading
     setModalContent(null); // Clear previous content
 

--- a/src/components/charts/Radial.tsx
+++ b/src/components/charts/Radial.tsx
@@ -182,11 +182,12 @@ export const RadialChart: React.FC<RadialChartProps> = ({
   // Close modal
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setModalContent(null); // Clear content when modal closes
   };
 
   // Fetch insights from the API
   const fetchInsights = async () => {
+    if (modalContent) return; // Don't fetch if there are insights already
+
     setIsLoading(true); // Start loading
     setModalContent(null); // Clear previous content
 


### PR DESCRIPTION
Closes #84 

## Changes:
- `modalContent` doesn't get cleared when closed
- `fetchInsights` terminates early when `modalContent` already exists

https://github.com/user-attachments/assets/dc5c4377-a82a-48e5-a131-0a0c995969a7

